### PR TITLE
chore: rename org references to pretty-good-software-org

### DIFF
--- a/.github/workflows/publish-provider-package.yml
+++ b/.github/workflows/publish-provider-package.yml
@@ -1,27 +1,96 @@
 name: Publish Provider Package
 
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
       version:
         description: "Version string to use while publishing the package (e.g. v1.0.0-alpha.1)"
         default: ''
         required: false
-      go-version:
-        description: 'Go version to use if building needs to be done'
-        default: '1.24'
-        required: false
+
+env:
+  GO_VERSION: '1.24'
+  DOCKER_BUILDX_VERSION: 'v0.30.1'
 
 jobs:
-  publish-provider-package:
-    uses: crossplane-contrib/provider-workflows/.github/workflows/publish-provider.yml@main
-    with:
-      registry_org: miaits
-      repository: provider-hetzner
-      version: ${{ github.event.inputs.version }}
-      go-version: ${{ github.event.inputs.go-version }}
-      cleanup-disk: true
-    secrets:
-      GHCR_PAT: ${{ secrets.GITHUB_TOKEN }}
-      XPKG_MIRROR_TOKEN: ${{ secrets.XPKG_MIRROR_TOKEN }}
-      XPKG_MIRROR_ACCESS_ID: ${{ secrets.XPKG_MIRROR_ACCESS_ID }}
+  publish:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: all
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          version: ${{ env.DOCKER_BUILDX_VERSION }}
+          install: true
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          submodules: true
+
+      - name: Fetch History
+        run: git fetch --prune --unshallow
+
+      - name: Setup Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Find the Go Build Cache
+        id: go
+        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
+
+      - name: Cache the Go Build Cache
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-publish-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-publish-
+
+      - name: Cache Go Dependencies
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: .work/pkg
+          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-pkg-
+
+      - name: Vendor Dependencies
+        run: make vendor vendor.check
+
+      - name: Build Artifacts
+        run: |
+          if [ -n "$VERSION_OVERRIDE" ]; then
+            make -j2 build.all VERSION="$VERSION_OVERRIDE"
+          else
+            make -j2 build.all
+          fi
+        env:
+          VERSION_OVERRIDE: ${{ github.event.inputs.version }}
+
+      - name: Publish Package
+        run: |
+          if [ -n "$VERSION_OVERRIDE" ]; then
+            make publish VERSION="$VERSION_OVERRIDE"
+          else
+            make publish
+          fi
+        env:
+          VERSION_OVERRIDE: ${{ github.event.inputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -65,17 +65,17 @@ CROSSPLANE_VERSION = 2.1.3
 # ====================================================================================
 # Setup Images
 
-REGISTRY_ORGS ?= ghcr.io/prettygood-software
+REGISTRY_ORGS ?= ghcr.io/pretty-good-software-org
 IMAGES = $(PROJECT_NAME)
 -include build/makelib/imagelight.mk
 
 # ====================================================================================
 # Setup XPKG
 
-XPKG_REG_ORGS ?= ghcr.io/prettygood-software
+XPKG_REG_ORGS ?= ghcr.io/pretty-good-software-org
 # NOTE(hasheddan): skip promoting on xpkg.crossplane.io as channel tags are
 # inferred.
-XPKG_REG_ORGS_NO_PROMOTE ?= ghcr.io/prettygood-software
+XPKG_REG_ORGS_NO_PROMOTE ?= ghcr.io/pretty-good-software-org
 XPKGS = $(PROJECT_NAME)
 -include build/makelib/xpkg.mk
 

--- a/Makefile
+++ b/Makefile
@@ -65,17 +65,17 @@ CROSSPLANE_VERSION = 2.1.3
 # ====================================================================================
 # Setup Images
 
-REGISTRY_ORGS ?= ghcr.io/crossplane-contrib
+REGISTRY_ORGS ?= ghcr.io/prettygood-software
 IMAGES = $(PROJECT_NAME)
 -include build/makelib/imagelight.mk
 
 # ====================================================================================
 # Setup XPKG
 
-XPKG_REG_ORGS ?= ghcr.io/crossplane-contrib
+XPKG_REG_ORGS ?= ghcr.io/prettygood-software
 # NOTE(hasheddan): skip promoting on xpkg.crossplane.io as channel tags are
 # inferred.
-XPKG_REG_ORGS_NO_PROMOTE ?= ghcr.io/crossplane-contrib
+XPKG_REG_ORGS_NO_PROMOTE ?= ghcr.io/prettygood-software
 XPKGS = $(PROJECT_NAME)
 -include build/makelib/xpkg.mk
 


### PR DESCRIPTION
Part of the org rename sweep.

## Changed
- Updated GHCR registry paths for image and XPKG publishing

## Intentionally kept (wave 2)
None

## Notes
Updated Makefile registry vars for GHCR image and XPKG publishing. Build depends on Go download phase for many K8s/Crossplane dependencies.